### PR TITLE
Add Currency Conversions

### DIFF
--- a/config/portfolio_definitions/core.yaml
+++ b/config/portfolio_definitions/core.yaml
@@ -535,3 +535,13 @@ transactions:
     price: 89.11
     quantity: 225
     currency: USD
+  
+  # Conversion rate must be rate for 'from' currency to 'to' currency
+  # Currently only USD<->CAD is supported
+  # Conversions must be made on valid trading dates
+  - type: Conversion
+    date: 2025-10-14
+    amount: 2166.75
+    currency_from: USD
+    currency_to: CAD
+    conversion_rate: 1.3821

--- a/scripts/derive_trades_from_yaml.py
+++ b/scripts/derive_trades_from_yaml.py
@@ -1,7 +1,9 @@
-"""Derive `data/<portfolio>/input/trades.csv` from YAML portfolio definitions.
+"""Derive input CSVs from YAML portfolio definitions.
 
 Reads `config/portfolio_definitions/<portfolio>.yaml`, normalizes transactions,
-and writes a sorted CSV with headers: Date, Ticker, Currency, Quantity, Price.
+and writes sorted CSVs in `data/<portfolio>/input`:
+  - trades.csv with headers: Date, Ticker, Currency, Quantity, Price (Buy/Sell only)
+  - conversions.csv with headers: Date, Currency_From, Currency_To, Amount, Rate
 
 Usage:
     python scripts/derive_trades_from_yaml.py [portfolio ...]
@@ -62,24 +64,66 @@ def _normalize_row(tx: Dict[str, Any]) -> Dict[str, Any]:
     }
 
 
-def derive_trades_for_portfolio(portfolio_name: str) -> str:
-    """Derive trades.csv from YAML for a given portfolio and return output path."""
-    transactions = _load_transactions_from_yaml(portfolio_name)
-    rows = [_normalize_row(tx) for tx in transactions]
+def _normalize_conversion_row(tx: Dict[str, Any]) -> Dict[str, Any]:
+    """Normalize a conversion transaction into a standardized dict.
 
-    # Sort rows deterministically by Date then Ticker
-    rows.sort(key=lambda r: (r['Date'], r['Ticker']))
+    Rate semantics: units of Currency_To per 1 unit of Currency_From.
+    Example: USD->CAD at 1.3821 means 1 USD = 1.3821 CAD.
+    """
+    date = str(tx.get('date', '')).strip()
+    currency_from = str(tx.get('currency_from', '')).strip().upper()
+    currency_to = str(tx.get('currency_to', '')).strip().upper()
+    amount = float(tx.get('amount'))
+    rate_val = tx.get('conversion_rate')
+    rate = float(rate_val) if rate_val is not None else float('nan')
+
+    logger.info(f"Conversion parsed: {amount} {currency_from} -> {currency_to} at rate {rate}")
+
+    return {
+        'Date': date,
+        'Currency_From': currency_from,
+        'Currency_To': currency_to,
+        'Amount': amount,
+        'Rate': rate,
+    }
+
+
+def derive_trades_for_portfolio(portfolio_name: str) -> str:
+    """Derive input CSVs (trades, conversions) from YAML and return trades path."""
+    transactions = _load_transactions_from_yaml(portfolio_name)
+    trade_rows: List[Dict[str, Any]] = []
+    conversion_rows: List[Dict[str, Any]] = []
+
+    for tx in transactions:
+        tx_type = str(tx.get('type', '')).strip().lower()
+        if tx_type == 'conversion':
+            conversion_rows.append(_normalize_conversion_row(tx))
+        else:
+            trade_rows.append(_normalize_row(tx))
+
+    # Sort rows deterministically
+    trade_rows.sort(key=lambda r: (r['Date'], r['Ticker']))
+    conversion_rows.sort(key=lambda r: (r['Date'], r['Currency_From'], r['Currency_To']))
 
     input_dir = os.path.join(PROJECT_ROOT, 'data', portfolio_name, 'input')
     os.makedirs(input_dir, exist_ok=True)
     output_csv = os.path.join(input_dir, 'trades.csv')
+    conversions_csv = os.path.join(input_dir, 'conversions.csv')
 
     with open(output_csv, 'w', newline='', encoding='utf-8') as f:
         writer = csv.DictWriter(
             f, fieldnames=['Date', 'Ticker', 'Currency', 'Quantity', 'Price']
         )
         writer.writeheader()
-        for row in rows:
+        for row in trade_rows:
+            writer.writerow(row)
+
+    with open(conversions_csv, 'w', newline='', encoding='utf-8') as f:
+        writer = csv.DictWriter(
+            f, fieldnames=['Date', 'Currency_From', 'Currency_To', 'Amount', 'Rate']
+        )
+        writer.writeheader()
+        for row in conversion_rows:
             writer.writerow(row)
 
     return output_csv


### PR DESCRIPTION
Closes #116 

The fund sometimes does currency conversions (as of recently) but adding these transactions was not supported in our system. Now currency conversions only between CAD and USD (and vice versa) are accounted for in our cash holdings by creating a conversions table that is referenced when building the cash table.