### PR TITLE
Add Search bar for holdings

### DIFF
--- a/src/views/holdings_table.py
+++ b/src/views/holdings_table.py
@@ -22,7 +22,7 @@ def render_holdings_table(holdings_data: pd.DataFrame):
     if selected_tickers:
         display_data = holdings_data[holdings_data['ticker'].isin(selected_tickers)]
     else:
-        display_data = holdings_data
+        display_data = holdings_data.copy()
 
     if not holdings_data.empty:
         # Select columns to show (keep numeric types for proper sorting)


### PR DESCRIPTION
closes (#149) 

Added search bar for holdings. Works pretty well and is surprisingly simple. 


<img width="1497" height="785" alt="Screenshot 2026-01-19 at 12 46 08 PM" src="https://github.com/user-attachments/assets/eaae8974-9d04-4aeb-9f73-8ed20004aab4" />

<img width="1521" height="770" alt="Screenshot 2026-01-19 at 12 46 45 PM" src="https://github.com/user-attachments/assets/76dba229-26c5-49fb-a3d6-39a5822d10ae" />

<img width="1522" height="474" alt="Screenshot 2026-01-19 at 12 47 03 PM" src="https://github.com/user-attachments/assets/dd9276ee-8638-420b-a607-3005702e32aa" />


