### PR TITLE
Added code for bench mark

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -120,7 +120,16 @@ def main():
 
     # Fetch cumulative returns (since inception) and render chart at the top
     try:
-        returns_df = portfolio_controller.get_cumulative_returns()
+        core_portfolio_name = next(
+            (p for p in available_portfolios if p.lower() == "core"),
+            None,
+        )
+        returns_controller = (
+            PortfolioController(core_portfolio_name)
+            if core_portfolio_name
+            else portfolio_controller
+        )
+        returns_df = returns_controller.get_cumulative_returns()
         render_returns_chart(returns_df)
         if selected_portfolio.lower() == "benchmark":
             _project_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))


### PR DESCRIPTION
<img width="1833" height="563" alt="Screenshot 2026-03-30 at 11 19 51 PM" src="https://github.com/user-attachments/assets/6c90e2ae-1283-458a-86b9-ff06f18da3d1" />
<img width="1867" height="690" alt="Screenshot 2026-03-30 at 11 20 01 PM" src="https://github.com/user-attachments/assets/991f5c7a-877e-4760-9f91-bad571c72ccb" />

changed it so the returns chart is no longer dynamic. it always shows the Core portfolio’s returns.
